### PR TITLE
Feature/phase 2 news item slugs

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -20,7 +20,7 @@ exports.createPages = async ({ actions, graphql }) => {
           node {
             contentful_id
             title
-            date
+            slug
           }
         }
       }
@@ -29,14 +29,22 @@ exports.createPages = async ({ actions, graphql }) => {
 
   // Create single news page(s)
   data.allContentfulNewsItem.edges.forEach(edge => {
-    const slug = convertTitleToSlug(edge.node.title)
-    const id = edge.node["contentful_id"]
-    const date = edge.node.date
+    const { title, slug, contentful_id } = edge.node
+    const id = contentful_id
+    let determinedSlug
+
+    if (slug) {
+      determinedSlug = convertTitleToSlug(slug)
+    } else if (!slug && title) {
+      determinedSlug = convertTitleToSlug(title)
+    } else if (!slug && !title && contentful_id) {
+      determinedSlug = contentful_id
+    }
 
     actions.createPage({
-      path: `news${date ? '/' + date : ''}/${slug ? slug : id}`,
+      path: `news/${determinedSlug}`,
       component: require.resolve("./src/templates/singleNews.js"),
-      context: { id }, // Pass ID to get news item in template
+      context: { id },
     })
   })
 }

--- a/src/components/helpers.js
+++ b/src/components/helpers.js
@@ -12,3 +12,13 @@ export function convertTitleToSlug(title) {
 
   return null
 }
+
+export function determineSlug(slug, title, contentful_id) {
+  if (slug) {
+    return convertTitleToSlug(slug)
+  } else if (!slug && title) {
+    return convertTitleToSlug(title)
+  } else if (!slug && !title && contentful_id) {
+    return contentful_id
+  }
+}

--- a/src/components/newsArchive.js
+++ b/src/components/newsArchive.js
@@ -24,6 +24,7 @@ export default function NewsArchive() {
                 src
               }
             }
+            slug
           }
         }
       }
@@ -31,7 +32,7 @@ export default function NewsArchive() {
   `)
 
   const newsItems = data.allContentfulNewsItem.edges.reduce((news, curNews) => {
-    const { date, title, contentful_id } = curNews.node
+    const { date, title, contentful_id, slug } = curNews.node
     const summary =
       curNews.node.summary === null ? null : curNews.node.summary.summary
     const imgSrc =
@@ -42,11 +43,12 @@ export default function NewsArchive() {
       title,
       date,
       contentfulId: contentful_id,
+      slug,
       summary,
       imgSrc,
     }
 
-    news.push(newNewsItem);
+    news.push(newNewsItem)
 
     return news
   }, [])
@@ -61,6 +63,7 @@ export default function NewsArchive() {
             title={item.title}
             key={item.contentfulId}
             contentful_id={item.contentfulId}
+            slug={item.slug}
           />
         )
       })}

--- a/src/components/newsBottomHeaderArea.js
+++ b/src/components/newsBottomHeaderArea.js
@@ -2,7 +2,7 @@ import React from "react"
 import { Link, useStaticQuery, graphql } from "gatsby"
 import "./newsBottomHeaderArea.scss"
 
-import { convertTitleToSlug } from "./helpers"
+import { determineSlug } from "./helpers"
 
 export default function NewsBottomHeaderArea() {
   const data = useStaticQuery(graphql`
@@ -44,11 +44,7 @@ export default function NewsBottomHeaderArea() {
     slug,
     headerImage,
   } = data.allContentfulSingleton.edges[0].node.entry
-  let formattedSlug = slug
-    ? convertTitleToSlug(slug)
-    : title
-    ? convertTitleToSlug(title)
-    : contentful_id
+  const formattedSlug = determineSlug(slug, title, contentful_id)
 
   return (
     <>

--- a/src/components/newsBottomHeaderArea.js
+++ b/src/components/newsBottomHeaderArea.js
@@ -27,6 +27,7 @@ export default function NewsBottomHeaderArea() {
                   summary
                 }
                 contentful_id
+                slug
               }
             }
           }
@@ -40,10 +41,15 @@ export default function NewsBottomHeaderArea() {
     date,
     summary,
     contentful_id,
+    slug,
     headerImage,
   } = data.allContentfulSingleton.edges[0].node.entry
-  const slug = title ? convertTitleToSlug(title) : null
- 
+  let formattedSlug = slug
+    ? convertTitleToSlug(slug)
+    : title
+    ? convertTitleToSlug(title)
+    : contentful_id
+
   return (
     <>
       <div className="bottom-left">
@@ -58,7 +64,7 @@ export default function NewsBottomHeaderArea() {
         {contentful_id && (
           <Link
             className="bottom-left__link"
-            to={`/news${date ? "/" + date : ""}/${slug ? slug : contentful_id}`}
+            to={`/news/${formattedSlug ? formattedSlug : contentful_id}`}
           >
             <div className="bottom-left__more"></div>
           </Link>

--- a/src/components/newsBottomHeaderArea.js
+++ b/src/components/newsBottomHeaderArea.js
@@ -62,10 +62,7 @@ export default function NewsBottomHeaderArea() {
           <div className="bottom-left__description">{summary.summary}</div>
         )}
         {contentful_id && (
-          <Link
-            className="bottom-left__link"
-            to={`/news/${formattedSlug ? formattedSlug : contentful_id}`}
-          >
+          <Link className="bottom-left__link" to={`/news/${formattedSlug}`}>
             <div className="bottom-left__more"></div>
           </Link>
         )}

--- a/src/components/newsFeed.js
+++ b/src/components/newsFeed.js
@@ -28,6 +28,7 @@ export default function NewsFeed({ contentContainerRef }) {
                 src
               }
             }
+            slug
           }
         }
       }
@@ -46,7 +47,7 @@ export default function NewsFeed({ contentContainerRef }) {
   }, [width, contentContainerRef])
 
   const newsItems = data.allContentfulNewsItem.edges.reduce((news, curNews) => {
-    const { date, title, contentful_id } = curNews.node
+    const { date, title, contentful_id, slug } = curNews.node
     const summary =
       curNews.node.summary === null ? null : curNews.node.summary.summary
     const imgSrc =
@@ -57,6 +58,7 @@ export default function NewsFeed({ contentContainerRef }) {
       title,
       date,
       contentfulId: contentful_id,
+      slug,
       summary,
       imgSrc,
     }
@@ -68,7 +70,6 @@ export default function NewsFeed({ contentContainerRef }) {
     return news
   }, [])
 
-  console.log(data)
   return (
     <div className="news-feed">
       <div className="news-feed__container">
@@ -81,6 +82,7 @@ export default function NewsFeed({ contentContainerRef }) {
                 title={item.title}
                 description={item.summary}
                 contentful_id={item.contentfulId}
+                slug={item.slug}
                 key={item.contentfulId}
                 hoverEffects={width > 889 ? true : false}
               />

--- a/src/components/newsItem.js
+++ b/src/components/newsItem.js
@@ -2,7 +2,7 @@ import React from "react"
 import { Link } from "gatsby"
 import "./newsItem.scss"
 
-import { convertTitleToSlug } from "./helpers"
+import { determineSlug } from "./helpers"
 
 export default function NewsItem({
   image,
@@ -14,21 +14,14 @@ export default function NewsItem({
   hoverEffects,
 }) {
   const renderNewsItem = () => {
-    const formattedSlug = slug
-      ? convertTitleToSlug(slug)
-      : title
-      ? convertTitleToSlug(title)
-      : contentful_id
+    const formattedSlug = determineSlug(slug, title, contentful_id)
 
     return (
       <div
         className={hoverEffects ? "news-item news-item--hover" : "news-item"}
       >
         <div className="news-item__back-panel"></div>
-        <Link
-          className="news-item__link"
-          to={`/news/${formattedSlug}`}
-        >
+        <Link className="news-item__link" to={`/news/${formattedSlug}`}>
           <div className="news-item__wrapper">
             <div className="news-item__image-container">
               {image && (

--- a/src/components/newsItem.js
+++ b/src/components/newsItem.js
@@ -10,10 +10,15 @@ export default function NewsItem({
   title,
   description,
   contentful_id,
+  slug,
   hoverEffects,
 }) {
   const renderNewsItem = () => {
-    const slug = convertTitleToSlug(title)
+    const formattedSlug = slug
+      ? convertTitleToSlug(slug)
+      : title
+      ? convertTitleToSlug(title)
+      : contentful_id
 
     return (
       <div
@@ -22,7 +27,7 @@ export default function NewsItem({
         <div className="news-item__back-panel"></div>
         <Link
           className="news-item__link"
-          to={`/news${date ? "/" + date : ""}/${slug ? slug : contentful_id}`}
+          to={`/news/${formattedSlug}`}
         >
           <div className="news-item__wrapper">
             <div className="news-item__image-container">
@@ -51,7 +56,9 @@ export default function NewsItem({
 
   return (
     <React.Fragment>
-      {contentful_id && (image || date || title || description) && renderNewsItem()}
+      {contentful_id &&
+        (image || date || title || description) &&
+        renderNewsItem()}
     </React.Fragment>
   )
 }

--- a/src/components/whereItStarted.js
+++ b/src/components/whereItStarted.js
@@ -1,7 +1,7 @@
 import React from "react"
 import { graphql, useStaticQuery } from "gatsby"
 import { useWindowSize } from "./hooks"
-import { convertTitleToSlug } from "./helpers"
+import { determineSlug } from "./helpers"
 import "./whereItStarted.scss"
 import Button from "./button"
 
@@ -31,11 +31,7 @@ export default function WhereItStarted() {
     slug,
     contentful_id,
   } = data.allContentfulNewsItem.edges[0].node
-  const formattedSlug = slug
-    ? convertTitleToSlug(slug)
-    : title
-    ? convertTitleToSlug(title)
-    : contentful_id
+  const formattedSlug = determineSlug(slug, title, contentful_id)
   const url = `/news/${formattedSlug}`
 
   return (

--- a/src/components/whereItStarted.js
+++ b/src/components/whereItStarted.js
@@ -17,17 +17,26 @@ export default function WhereItStarted() {
       ) {
         edges {
           node {
-            date
             title
+            slug
+            contentful_id
           }
         }
       }
     }
   `)
 
-  const {date, title} = data.allContentfulNewsItem.edges[0].node
-
-  const slug = (date && title) ? `/news/${date}/${convertTitleToSlug(title)}` : null
+  const {
+    title,
+    slug,
+    contentful_id,
+  } = data.allContentfulNewsItem.edges[0].node
+  const formattedSlug = slug
+    ? convertTitleToSlug(slug)
+    : title
+    ? convertTitleToSlug(title)
+    : contentful_id
+  const url = `/news/${formattedSlug}`
 
   return (
     <div className="where-it-all-started">
@@ -43,7 +52,7 @@ export default function WhereItStarted() {
               exhibitions of Latin American and Latino art in cultural
               institutions and museums across Southern California.
             </p>
-            {slug && <Button url={slug} text="Learn More" />}
+            {url && <Button url={url} text="Learn More" />}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Updates news item slugs to use slug provided by contentful if it exists. And falls back to the title and ID if needed. The date is removed from the slug.

***Note***
- Will update look into consolidating the use of convertTitleToSlug in components/gatsby-node in resources page branch

### Screenshots
![Screen Shot 2021-02-03 at 10 44 21 AM](https://user-images.githubusercontent.com/25031031/106787458-f7ebd280-660c-11eb-94f5-c23f8e9265ea.png)
![Screen Shot 2021-02-03 at 10 44 38 AM](https://user-images.githubusercontent.com/25031031/106787473-fae6c300-660c-11eb-96c9-4298d7f3524d.png)
![Screen Shot 2021-02-03 at 10 45 16 AM](https://user-images.githubusercontent.com/25031031/106787468-f9b59600-660c-11eb-832b-658aab385710.png)
![Screen Shot 2021-02-03 at 10 45 05 AM](https://user-images.githubusercontent.com/25031031/106787471-fa4e2c80-660c-11eb-836f-280fccac00bf.png)

